### PR TITLE
Return dictionary instead of list

### DIFF
--- a/paq2py.py
+++ b/paq2py.py
@@ -99,4 +99,8 @@ def paq_read(file_path=None, plot=False):
             ax.set_title(chan_names[idx])
         plt.show()
 
-    return data, chan_names, hw_chans, units, rate
+    return {"data": data, 
+            "chan_names": chan_names,
+            "hw_chans": hw_chans,
+            "units": units,
+            "rate": rate}


### PR DESCRIPTION
I'd recommend returning a dictionary to clarify what the function returns. Otherwise it's difficult to remember what "output[0]" means.
