### PR TITLE
Numpy update related deprecation

### DIFF
--- a/paq2py.py
+++ b/paq2py.py
@@ -80,7 +80,7 @@ def paq_read(file_path=None, plot=False):
 
     # get data
     temp_data = np.fromfile(fid, dtype='>f', count=-1)
-    num_datapoints = len(temp_data)/num_chans
+    num_datapoints = int(len(temp_data)/num_chans)
     data = np.reshape(temp_data, [num_datapoints, num_chans]).transpose()
 
     # close file


### PR DESCRIPTION
Lines 83-84 of paq2py.py, 

    num_datapoints = len(temp_data)/num_chans
    data = np.reshape(temp_data, [num_datapoints, num_chans]).transpose( )
becomes
    num_datapoints = int(len(temp_data)/num_chans )
    data = np.reshape(temp_data, [num_datapoints, num_chans]).transpose( )

You may want to edit your github script.

Max

PS: the exact error was

Traceback (most recent call last):

  File "<ipython-input-328-6844128caf8b>", line 3, in <module>
    paq = paq2py.paq_read(paq_dp+'/'+paq_f)

  File "/home/ms047/anaconda3/envs/py3/lib/python3.6/site-packages/paq2py.py", line 84, in paq_read
    data = np.reshape(temp_data, [num_datapoints, num_chans]).transpose()

  File "/home/ms047/anaconda3/envs/py3/lib/python3.6/site-packages/numpy/core/fromnumeric.py", line 279, in reshape
    return _wrapfunc(a, 'reshape', newshape, order=order)

  File "/home/ms047/anaconda3/envs/py3/lib/python3.6/site-packages/numpy/core/fromnumeric.py", line 61, in _wrapfunc
    return _wrapit(obj, method, *args, **kwds)

  File "/home/ms047/anaconda3/envs/py3/lib/python3.6/site-packages/numpy/core/fromnumeric.py", line 41, in _wrapit
    result = getattr(asarray(obj), method)(*args, **kwds)

TypeError: 'float' object cannot be interpreted as an integer